### PR TITLE
feature: new way to get rust release informations / we need postInstall to do something rustup will do

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+.available.cache

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# My View
+
+Rust has constructed a circle of dependence, I recommend rustup instead.
+
+
 # vfox-rust
 
 rust plugin for [vfox](https://vfox.dev/) .

--- a/hooks/available.lua
+++ b/hooks/available.lua
@@ -1,133 +1,32 @@
 --- Return all available versions provided by this plugin
 --- @param ctx table Empty table used as context, for future extension
 --- @return table Descriptions of available versions and accompanying tool descriptions
+
+local http = require("http")
+local URL = "https://releases.rs/"
+
 function PLUGIN:Available(ctx)
-    return {
-        {version = "1.90.0", note = "latest", addition = {}},
-        {version = "1.89.0", note = "", addition = {}},
-        {version = "1.88.0", note = "", addition = {}},
-        {version = "1.87.0", note = "", addition = {}},
-        {version = "1.86.0", note = "", addition = {}},
-        {version = "1.85.1", note = "", addition = {}},
-        {version = "1.85.0", note = "", addition = {}},
-        {version = "1.84.1", note = "", addition = {}},
-        {version = "1.84.0", note = "", addition = {}},
-        {version = "1.83.0", note = "", addition = {}},
-        {version = "1.82.0", note = "", addition = {}},
-        {version = "1.81.0", note = "", addition = {}},
-        {version = "1.80.1", note = "", addition = {}},
-        {version = "1.80.0", note = "", addition = {}},
-        {version = "1.79.0", note = "", addition = {}},
-        {version = "1.78.0", note = "", addition = {}},
-        {version = "1.77.2", note = "", addition = {}},
-        {version = "1.77.1", note = "", addition = {}},
-        {version = "1.77.0", note = "", addition = {}},
-        {version = "1.76.0", note = "", addition = {}},
-        {version = "1.75.0", note = "", addition = {}},
-        {version = "1.74.1", note = "", addition = {}},
-        {version = "1.74.0", note = "", addition = {}},
-        {version = "1.73.0", note = "", addition = {}},
-        {version = "1.72.1", note = "", addition = {}},
-        {version = "1.72.0", note = "", addition = {}},
-        {version = "1.71.1", note = "", addition = {}},
-        {version = "1.71.0", note = "", addition = {}},
-        {version = "1.70.0", note = "", addition = {}},
-        {version = "1.69.0", note = "", addition = {}},
-        {version = "1.68.2", note = "", addition = {}},
-        {version = "1.68.1", note = "", addition = {}},
-        {version = "1.68.0", note = "", addition = {}},
-        {version = "1.67.1", note = "", addition = {}},
-        {version = "1.67.0", note = "", addition = {}},
-        {version = "1.66.1", note = "", addition = {}},
-        {version = "1.66.0", note = "", addition = {}},
-        {version = "1.65.0", note = "", addition = {}},
-        {version = "1.64.0", note = "", addition = {}},
-        {version = "1.63.0", note = "", addition = {}},
-        {version = "1.62.1", note = "", addition = {}},
-        {version = "1.62.0", note = "", addition = {}},
-        {version = "1.61.0", note = "", addition = {}},
-        {version = "1.60.0", note = "", addition = {}},
-        {version = "1.59.0", note = "", addition = {}},
-        {version = "1.58.1", note = "", addition = {}},
-        {version = "1.58.0", note = "", addition = {}},
-        {version = "1.57.0", note = "", addition = {}},
-        {version = "1.56.1", note = "", addition = {}},
-        {version = "1.56.0", note = "", addition = {}},
-        {version = "1.55.0", note = "", addition = {}},
-        {version = "1.54.0", note = "", addition = {}},
-        {version = "1.53.0", note = "", addition = {}},
-        {version = "1.52.1", note = "", addition = {}},
-        {version = "1.52.0", note = "", addition = {}},
-        {version = "1.51.0", note = "", addition = {}},
-        {version = "1.50.0", note = "", addition = {}},
-        {version = "1.49.0", note = "", addition = {}},
-        {version = "1.48.0", note = "", addition = {}},
-        {version = "1.47.0", note = "", addition = {}},
-        {version = "1.46.0", note = "", addition = {}},
-        {version = "1.45.2", note = "", addition = {}},
-        {version = "1.45.1", note = "", addition = {}},
-        {version = "1.45.0", note = "", addition = {}},
-        {version = "1.44.1", note = "", addition = {}},
-        {version = "1.44.0", note = "", addition = {}},
-        {version = "1.43.1", note = "", addition = {}},
-        {version = "1.43.0", note = "", addition = {}},
-        {version = "1.42.0", note = "", addition = {}},
-        {version = "1.41.1", note = "", addition = {}},
-        {version = "1.41.0", note = "", addition = {}},
-        {version = "1.40.0", note = "", addition = {}},
-        {version = "1.39.0", note = "", addition = {}},
-        {version = "1.38.0", note = "", addition = {}},
-        {version = "1.37.0", note = "", addition = {}},
-        {version = "1.36.0", note = "", addition = {}},
-        {version = "1.35.0", note = "", addition = {}},
-        {version = "1.34.2", note = "", addition = {}},
-        {version = "1.34.1", note = "", addition = {}},
-        {version = "1.34.0", note = "", addition = {}},
-        {version = "1.33.0", note = "", addition = {}},
-        {version = "1.32.0", note = "", addition = {}},
-        {version = "1.31.1", note = "", addition = {}},
-        {version = "1.31.0", note = "", addition = {}},
-        {version = "1.30.1", note = "", addition = {}},
-        {version = "1.30.0", note = "", addition = {}},
-        {version = "1.29.2", note = "", addition = {}},
-        {version = "1.29.1", note = "", addition = {}},
-        {version = "1.29.0", note = "", addition = {}},
-        {version = "1.28.0", note = "", addition = {}},
-        {version = "1.27.2", note = "", addition = {}},
-        {version = "1.27.1", note = "", addition = {}},
-        {version = "1.27.0", note = "", addition = {}},
-        {version = "1.26.2", note = "", addition = {}},
-        {version = "1.26.1", note = "", addition = {}},
-        {version = "1.26.0", note = "", addition = {}},
-        {version = "1.25.0", note = "", addition = {}},
-        {version = "1.24.1", note = "", addition = {}},
-        {version = "1.24.0", note = "", addition = {}},
-        {version = "1.23.0", note = "", addition = {}},
-        {version = "1.22.1", note = "", addition = {}},
-        {version = "1.22.0", note = "", addition = {}},
-        {version = "1.21.0", note = "", addition = {}},
-        {version = "1.20.0", note = "", addition = {}},
-        {version = "1.19.0", note = "", addition = {}},
-        {version = "1.18.0", note = "", addition = {}},
-        {version = "1.17.0", note = "", addition = {}},
-        {version = "1.16.0", note = "", addition = {}},
-        {version = "1.15.1", note = "", addition = {}},
-        {version = "1.15.0", note = "", addition = {}},
-        {version = "1.14.0", note = "", addition = {}},
-        {version = "1.13.0", note = "", addition = {}},
-        {version = "1.12.1", note = "", addition = {}},
-        {version = "1.12.0", note = "", addition = {}},
-        {version = "1.11.0", note = "", addition = {}},
-        {version = "1.10.0", note = "", addition = {}},
-        {version = "1.9.0", note = "", addition = {}},
-        {version = "1.8.0", note = "", addition = {}},
-        {version = "1.7.0", note = "", addition = {}},
-        {version = "1.6.0", note = "", addition = {}},
-        {version = "1.5.0", note = "", addition = {}},
-        {version = "1.4.0", note = "", addition = {}},
-        {version = "1.3.0", note = "", addition = {}},
-        {version = "1.2.0", note = "", addition = {}},
-        {version = "1.1.0", note = "", addition = {}},
-        {version = "1.0.0", note = "", addition = {}}
-    }
+
+    --- fetch from https://releases.rs/
+    local resp, err = http.get({
+        url = URL
+    })
+    if err ~= nil then
+        error("Failed to fetch rust dist info: " .. err)
+    end
+    if resp.status_code ~= 200 then
+        error("Failed to fetch rust dist info: status_code =>" .. resp.status_code)
+    end
+
+    --- get the html texts
+    local versions = {}
+    local latest = true
+    local list = resp.body:match("<ul>(.-)</ul>")
+    for version in list:gmatch('/docs/([^/]+)/') do
+        local note = latest and "latest" or ""
+        latest = false
+        table.insert(versions, {version = version, note = note, addition = {}})
+    end
+
+    return versions
 end

--- a/hooks/env_keys.lua
+++ b/hooks/env_keys.lua
@@ -5,31 +5,38 @@
 --- @field ctx.path string SDK installation directory
 function PLUGIN:EnvKeys(ctx)
     local mainPath = ctx.path
+    local osType = RUNTIME.osType:lower()
+    local separator = ""
+    if osType == "windows" then
+        separator = "\\"
+    else
+        separator = "/"
+    end
 
     return {
         {
             key = 'PATH',
-            value = mainPath .. "/rustc/bin",
+            value = mainPath .. separator .. "rustc" .. separator .. "bin",
         },
         {
             key = 'PATH',
-            value = mainPath .. "/cargo/bin",
+            value = mainPath .. separator .. "cargo" .. separator .. "bin",
         },
         {
             key = 'PATH',
-            value = mainPath .. "/clippy-preview/bin",
+            value = mainPath .. separator .. "clippy-preview" .. separator .. "bin",
         },
         {
             key = 'PATH',
-            value = mainPath .. "/rust-analyzer-preview/bin",
+            value = mainPath .. separator .. "rust-analyzer-preview" .. separator .. "bin",
         },
         {
             key = 'PATH',
-            value = mainPath .. "/rustfmt-preview/bin",
+            value = mainPath .. separator .. "rustfmt-preview" .. separator .."bin",
         },
         {
             key = 'CARGO_HOME',
-            value = mainPath .. '/cargo'
+            value = mainPath .. separator .. 'cargo'
         }
     }
 end

--- a/hooks/post_install.lua
+++ b/hooks/post_install.lua
@@ -1,0 +1,33 @@
+--- mv the libs from rust-std-xxx to rustc
+--- etc:
+--- .vfox\cache\rust\v-1.90.0\rust-1.90.0\rust-std-x86_64-pc-windows-msvc\lib\rustlib\x86_64-pc-windows-msvc\lib
+--- -> .vfox\cache\rust\v-1.90.0\rust-1.90.0\rustc\lib\rustlib\x86_64-pc-windows-msvc\lib
+---
+local utils = require("utils")
+local strings = require("vfox.strings")
+
+function PLUGIN:PostInstall(ctx)
+    local sdkInfo = ctx.sdkInfo['rust']
+    local mainPath = sdkInfo.path  --- refer to etc .vfox\cache\rust\v-1.90.0\rust-1.90.0
+    local osType = RUNTIME.osType:lower()
+    local archType = RUNTIME.archType:lower()
+    local platform = utils:getPlatform(osType, archType)
+    local separator = ""
+    if osType == "windows" then
+        separator = "\\"
+    else
+        separator = "/"
+    end
+    local sys_std_path = mainPath ..
+    separator .. "rust-std-" .. platform .. separator .. "lib" .. separator .. "rustlib" .. separator .. platform
+
+    local rustc_std_path = mainPath ..
+    separator .. "rustc" .. separator .. "lib" .. separator .. "rustlib" .. separator .. platform
+
+    --- here we need a way to move files
+    if osType == "windows" then
+        
+    else
+        
+    end
+end

--- a/hooks/post_install.lua
+++ b/hooks/post_install.lua
@@ -18,16 +18,19 @@ function PLUGIN:PostInstall(ctx)
     else
         separator = "/"
     end
-    local sys_std_path = mainPath ..
-    separator .. "rust-std-" .. platform .. separator .. "lib" .. separator .. "rustlib" .. separator .. platform
-
     local rustc_std_path = mainPath ..
-    separator .. "rustc" .. separator .. "lib" .. separator .. "rustlib" .. separator .. platform
+    separator .. "rust-std-" .. platform .. separator .. "lib" .. separator .. "rustlib" .. separator
 
-    --- here we need a way to move files
+    local sys_std_path = mainPath ..
+    separator .. "rustc" .. separator .. "lib" .. separator .. "rustlib" .. separator
+
     if osType == "windows" then
-        
+        local cmd = [[xcopy "]] .. rustc_std_path .. [[" "]] .. sys_std_path .. [[" /E /Y /I >nul]]
+        print(cmd)
+        os.execute(cmd)
     else
-        
+        local cmd = [[cp -rf "]] .. rustc_std_path .. [[" "]] .. sys_std_path .. [[" > /dev/null 2>&1]]
+        print(cmd)
+        os.execute(cmd)
     end
 end

--- a/hooks/post_install.lua
+++ b/hooks/post_install.lua
@@ -18,19 +18,30 @@ function PLUGIN:PostInstall(ctx)
     else
         separator = "/"
     end
-    local rustc_std_path = mainPath ..
+
+    local rustc_std_path_unix = mainPath ..
     separator .. "rust-std-" .. platform .. separator .. "lib" .. separator .. "rustlib" .. separator .. platform .. separator
 
-    local sys_std_path = mainPath ..
+    local rustc_std_path_windows = mainPath ..
+    separator .. "rust-std-" .. platform .. separator .. "lib" .. separator .. "rustlib" .. separator .."*"
+
+    local sys_std_path_unix = mainPath ..
     separator .. "rustc" .. separator .. "lib" .. separator .. "rustlib" .. separator
 
+    local sys_std_path_windows = mainPath ..
+    separator .. "rustc" .. separator .. "lib" .. separator .. "rustlib"
+
     if osType == "windows" then
-        --- local cmd = [[xcopy "]] .. rustc_std_path .. [[" "]] .. sys_std_path .. [[" /E /Y /I >nul]]
-        --- print(cmd)
-        --- os.execute(cmd)
-    else
-        local cmd = [[cp -rf "]] .. rustc_std_path .. [[" "]] .. sys_std_path .. [[" > /dev/null 2>&1]]
+        local cmd = [[powershell -c 'Copy-Item -Path "]] .. rustc_std_path_windows .. [[" -Destination "]] .. sys_std_path_windows .. [[" -Recurse -Force']]
+        print("")
+        print("Please run this command by your self to set up libstd:")
+        print("")
         print(cmd)
+        print("")
+        os.execute(cmd)
+    else
+        local cmd = [[cp -rf "]] .. rustc_std_path_unix .. [[" "]] .. sys_std_path_unix .. [[" > /dev/null 2>&1]]
+        --- print(cmd) need log no more
         os.execute(cmd)
     end
 end

--- a/hooks/post_install.lua
+++ b/hooks/post_install.lua
@@ -29,8 +29,8 @@ function PLUGIN:PostInstall(ctx)
         --- print(cmd)
         --- os.execute(cmd)
     else
-        --- local cmd = [[cp -rf "]] .. rustc_std_path .. [[" "]] .. sys_std_path .. [[" > /dev/null 2>&1]]
-        --- print(cmd)
-        --- os.execute(cmd)
+        local cmd = [[cp -rf "]] .. rustc_std_path .. [[" "]] .. sys_std_path .. [[" > /dev/null 2>&1]]
+        print(cmd)
+        os.execute(cmd)
     end
 end

--- a/hooks/post_install.lua
+++ b/hooks/post_install.lua
@@ -19,18 +19,18 @@ function PLUGIN:PostInstall(ctx)
         separator = "/"
     end
     local rustc_std_path = mainPath ..
-    separator .. "rust-std-" .. platform .. separator .. "lib" .. separator .. "rustlib" .. separator
+    separator .. "rust-std-" .. platform .. separator .. "lib" .. separator .. "rustlib" .. separator .. platform .. separator
 
     local sys_std_path = mainPath ..
     separator .. "rustc" .. separator .. "lib" .. separator .. "rustlib" .. separator
 
     if osType == "windows" then
-        local cmd = [[xcopy "]] .. rustc_std_path .. [[" "]] .. sys_std_path .. [[" /E /Y /I >nul]]
-        print(cmd)
-        os.execute(cmd)
+        --- local cmd = [[xcopy "]] .. rustc_std_path .. [[" "]] .. sys_std_path .. [[" /E /Y /I >nul]]
+        --- print(cmd)
+        --- os.execute(cmd)
     else
-        local cmd = [[cp -rf "]] .. rustc_std_path .. [[" "]] .. sys_std_path .. [[" > /dev/null 2>&1]]
-        print(cmd)
-        os.execute(cmd)
+        --- local cmd = [[cp -rf "]] .. rustc_std_path .. [[" "]] .. sys_std_path .. [[" > /dev/null 2>&1]]
+        --- print(cmd)
+        --- os.execute(cmd)
     end
 end

--- a/lib/utils.lua
+++ b/lib/utils.lua
@@ -3,7 +3,7 @@ local io = require("io")
 
 local utils = {}
 
-function utils:getPrebuiltVersionUrl(osType, archType, version)
+function utils:getPlatform(osType, archType)
     osType = osType:lower()
     archType = archType:lower()
 
@@ -29,8 +29,17 @@ function utils:getPrebuiltVersionUrl(osType, archType, version)
         archType = "aarch64"
     end
 
-    local url = RUST_URL .. "/rust-" .. version .. "-" .. archType .. "-" .. osType .. ".tar.gz"
+    return archType .. "-" .. osType
+end
 
+function utils:getPrebuiltVersion(osType, archType, version)
+    local platform = utils:getPlatform(osType, archType)
+    local prebuiltVersion = version .. "-" .. platform
+    return  prebuiltVersion
+end
+
+function utils:getPrebuiltVersionUrl(osType, archType, version)
+    local url = RUST_URL .. "/rust-" .. utils:getPrebuiltVersion(osType, archType, version) .. ".tar.gz"
     return url
 end
 


### PR DESCRIPTION
# new way to get rust release informations

Use the HTTP library to directly fetch the release list from releases.rs, then use regex to match and get the complete version list — no hardcoding needed.

# PostInstall

When using vfox to pull precompiled binaries from rust dist, Rust's libstd is included in a folder named like rust-std-platform. However, the default rustc sysroot is the rustc directory, which means we must additionally modify rustc's sysroot directory to compile normally. This approach is obviously non-compliant.

I believe moving or copying the lib files from the rust-std-platform directory to the rustc-related directory is a more appropriate behavior. However, vfox's Lua engine does not provide file I/O functionality, making it extremely difficult to add third-party libraries. Using system native commands is too complex (requires considering excessive factors such as folder existence, especially on Windows platforms).

Perhaps I will solve this problem in the future.

# Other

Fix a small bug. When install on windows the separator is wrong (but work fine hh). now it can use correct separator.